### PR TITLE
Fix duplicate key resolution

### DIFF
--- a/spec/dupekey_spec.lua
+++ b/spec/dupekey_spec.lua
@@ -1,0 +1,50 @@
+-- .vscode/settings.json <<
+--   "Lua.workspace.library": {
+--     "C:\\ProgramData\\chocolatey\\lib\\luarocks\\luarocks-2.4.4-win32\\systree\\share\\lua\\5.1": true
+--   },
+local busted = require 'busted'
+local assert = require 'luassert'
+local yaml = require 'tinyyaml'
+
+busted.describe("duplicate keys", function()
+  busted.it("preserves duplicate map keys in block style", function()
+    assert.same(
+      {
+        map = {
+          Fruit = "apple",
+          Fruit_1 = "orange",
+          Fruit_2 = "banana",
+          Vegetable = "celery",
+          Vegetable_1 = "cucumber",
+          Vegetable_2 = "broccoli"
+        }
+      },
+      yaml.parse([[
+        map:
+          Fruit : apple
+          Fruit : orange
+          Fruit : banana
+          Vegetable : celery
+          Vegetable : cucumber
+          Vegetable : broccoli
+      ]])
+    )
+  end)
+  busted.it("preserves duplicate map keys in flow style", function()
+    assert.same(
+      {
+        map = {
+          Fruit = "apple",
+          Fruit_1 = "orange",
+          Fruit_2 = "banana",
+          Vegetable = "celery",
+          Vegetable_1 = "cucumber",
+          Vegetable_2 = "broccoli"
+        }
+      },
+      yaml.parse([[
+        map: { Fruit: apple, Fruit: orange, Fruit: banana, Vegetable: celery, Vegetable: cucumber, Vegetable: broccoli }
+      ]])
+    )
+  end)
+end)

--- a/spec/dupekey_spec.lua
+++ b/spec/dupekey_spec.lua
@@ -6,45 +6,64 @@ local busted = require 'busted'
 local assert = require 'luassert'
 local yaml = require 'tinyyaml'
 
+local expected = {
+  map = {
+    Fruit = "apple",
+    Fruit_1 = "orange",
+    Fruit_2 = "banana",
+    Vegetable = "celery",
+    Vegetable_1 = "cucumber",
+    Vegetable_2 = "broccoli"
+  }
+}
+
 busted.describe("duplicate keys", function()
-  busted.it("preserves duplicate map keys in block style", function()
-    assert.same(
-      {
-        map = {
-          Fruit = "apple",
-          Fruit_1 = "orange",
-          Fruit_2 = "banana",
-          Vegetable = "celery",
-          Vegetable_1 = "cucumber",
-          Vegetable_2 = "broccoli"
-        }
-      },
-      yaml.parse([[
-        map:
-          Fruit : apple
-          Fruit : orange
-          Fruit : banana
-          Vegetable : celery
-          Vegetable : cucumber
-          Vegetable : broccoli
-      ]])
-    )
+  busted.describe("in block style", function()
+    busted.it("preserves duplicate map keys", function()
+      assert.same(
+        expected,
+        yaml.parse([[
+          map:
+            Fruit : apple
+            Fruit : orange
+            Fruit : banana
+            Vegetable : celery
+            Vegetable : cucumber
+            Vegetable : broccoli
+        ]])
+      )
+    end)
+    busted.it("recognizes existing _ keys", function()
+      assert.same(
+        expected,
+        yaml.parse([[
+          map:
+            Fruit   : apple
+            Fruit_1 : orange
+            Fruit   : banana
+            Vegetable   : celery
+            Vegetable_1 : cucumber
+            Vegetable   : broccoli
+        ]])
+      )
+    end)
   end)
-  busted.it("preserves duplicate map keys in flow style", function()
-    assert.same(
-      {
-        map = {
-          Fruit = "apple",
-          Fruit_1 = "orange",
-          Fruit_2 = "banana",
-          Vegetable = "celery",
-          Vegetable_1 = "cucumber",
-          Vegetable_2 = "broccoli"
-        }
-      },
-      yaml.parse([[
-        map: { Fruit: apple, Fruit: orange, Fruit: banana, Vegetable: celery, Vegetable: cucumber, Vegetable: broccoli }
-      ]])
-    )
+  busted.describe("in flow style", function()
+    busted.it("preserves duplicate map keys", function()
+      assert.same(
+        expected,
+        yaml.parse([[
+          map: { Fruit: apple, Fruit: orange, Fruit: banana, Vegetable: celery, Vegetable: cucumber, Vegetable: broccoli }
+        ]])
+      )
+    end)
+    busted.it("recognizes existing _ keys", function()
+      assert.same(
+        expected,
+        yaml.parse([[
+          map: { Fruit: apple, Fruit_1: orange, Fruit: banana, Vegetable: celery, Vegetable_1: cucumber, Vegetable: broccoli }
+        ]])
+      )
+    end)
   end)
 end)

--- a/tinyyaml.lua
+++ b/tinyyaml.lua
@@ -219,6 +219,18 @@ local function equalsline(line, needle)
   return startswith(line, needle) and isemptyline(ssub(line, #needle+1))
 end
 
+local function checkdupekey(map, key)
+  if map[key] ~= nil then
+    -- print("found a duplicate key '"..key.."' in line: "..line)
+    local suffix = 1
+    while map[key..'_'..suffix] do
+      suffix = suffix + 1
+    end
+    key = key ..'_'..suffix
+  end
+  return key
+end
+
 local function parseflowstyle(line, lines)
   local stack = {}
   while true do
@@ -247,6 +259,7 @@ local function parseflowstyle(line, lines)
       if stack[#stack].t == ':' then
         -- map
         local key = tremove(stack)
+        key.v = checkdupekey(stack[#stack].v, key.v)
         stack[#stack].v[key.v] = value.v
       elseif stack[#stack].t == '{' then
         -- set
@@ -641,15 +654,7 @@ function parsemap(line, lines, indent)
       error("failed to classify line: "..line)
     end
 
-    if map[key] ~= nil then
-      -- print("found a duplicate key '"..key.."' in line: "..line)
-      local suffix = 1
-      while map[key..'__'..suffix] do
-        suffix = suffix + 1
-      end
-      key = key ..'_'..suffix
-    end
-
+    key = checkdupekey(map, key)
     line = ltrim(line)
 
     if ssub(line, 1, 1) == '!' then


### PR DESCRIPTION
Resolves #8.

* Fixed the typo: `__` -> `_`
* Moved the duplicate-checking code to a separate function so that it can be shared between block and flow style maps

Added new unit tests to verify that this fix works. Verified that all other unit tests are working as well.

Thanks for this great little library!